### PR TITLE
Updated wiki pages to fix some links and correct some details (#982)

### DIFF
--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -2,13 +2,13 @@ The app is separated into two sections. One for the dungeon master and one for t
 
 ## Dungeon Master
 
-To use dungeon-revealer, the game master and the players must be on the same local network (usually a wifi network). The game master will start the server (see [Installation](https://github.com/maxb2/dungeon-revealer/wiki/Install)), navigate to the server's URL (`your-ip:3000/dm`) in a web browser, and then enter a password if it is set. At this point, they will be prompted to upload an image file of the map to share with the other players. The other players will navigate to the server (`your-ip:3000`) using their own browsers (laptop, tablet, or phone) and will remain at the home page. The connection information is displayed in command prompt for convenience.
+To use dungeon-revealer, the game master and the players must be on the same local network (usually a wifi network). The game master will start the server (see [Installation](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Install)), navigate to the server's URL (`your-ip:3000/dm`) in a web browser, and then enter a password if it is set. At this point, they will be prompted to upload an image file of the map to share with the other players. The other players will navigate to the server (`your-ip:3000`) using their own browsers (laptop, tablet, or phone) and will remain at the home page. The connection information is displayed in command prompt for convenience.
 
 To clear areas of the map, click and draw on the map. You can switch the brush mode by clicking the "Reveal" or "Shroud" button. Alternatively, you can select an area to clear or shroud by clicking the "Select Area" button. Whenever the game master clears some of the fog of war from the map and it is ready to share with the players, they will click "Send" and the revealed areas of the map will appear in the players' browsers. What appears as a shadow to the DM will appear as pure blackness to players, thus only revealing the cleared sections of the map to them. The "Mark" button will display a circle for a period of time to indicate a point of interest.
 
 To switch to a different map, click "Map Library", and then select one of the maps you have already uploaded and click "Load". The "LIVE" indicator in the lower right indicates if the map currently on the dungeon master page is being presented on the player page. The "Stop Sharing" button will blank the player page in preparation for a new map to be loaded.
 
-You can add a [token](https://github.com/maxb2/dungeon-revealer/wiki/Tokens) with the "Token" tool. Click anywhere on the map to place it. The token can be changed by opening the context menu trough right-clicking on a single token. You can alter its label, color and size.
+You can add a [token](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Tokens) with the "Token" tool. Click anywhere on the map to place it. The token can be changed by opening the context menu trough right-clicking on a single token. You can alter its label, color and size.
 
 ### Shortcuts
 

--- a/wiki/Tokens.md
+++ b/wiki/Tokens.md
@@ -23,7 +23,4 @@ To add a token, click on the token tool on the left control panel and then click
 ]
 
 
-
-***Tokens visible to players can also be moved by them.***
-
-Linking a note to a token can be useful for the DM. You can use it for creature/player stats, item descriptions, room notes, or anything else you can think of. Click the `Link` button to link a note to the token. You can choose an existing note or create a new one. See the [Notes](https://github.com/maxb2/dungeon-revealer/wiki/Notes) page for more details.
+Linking a note to a token can be useful for the DM. You can use it for creature/player stats, item descriptions, room notes, or anything else you can think of. Click the `Link` button to link a note to the token. You can choose an existing note or create a new one. See the [Notes](https://github.com/dungeon-revealer/dungeon-revealer/wiki/Notes) page for more details.


### PR DESCRIPTION
* Update Getting-Started.md

Updated links to point to https://github.com/dungeon-revealer/dungeon-revealer/ instead of https://github.com/maxb2/dungeon-revealer/

* Update Tokens.md

Updated Notes link to point to dungeon-revealer/dungeon-revealer instead of maxb2/dungeon-revealer.
Removed the "Tokens visible to players can be moved by players" as this is no longer true. Visibility and movement are now two separate options.